### PR TITLE
[ready] Doc and cleanup

### DIFF
--- a/include/tue/filesystem/crawler.h
+++ b/include/tue/filesystem/crawler.h
@@ -6,10 +6,8 @@
 #include "path.h"
 #include "boost/filesystem.hpp"
 
-namespace tue
-{
-namespace filesystem
-{
+namespace tue {
+namespace filesystem {
 
 /**
  * File system crawler, recursively walk over all files and directories in
@@ -28,31 +26,46 @@ public:
      * Enable or disable iterating over sub-directories.
      * @param b Whether to expand sub-directories too.
      */
-    void setRecursive(bool b = true) { recursive_ = b; }
+    void setRecursive(bool b = true)
+    {
+        recursive_ = b;
+    }
 
     /**
      * Enable or disable iterating over hidden directories.
      * @param b Whether to skip hidden directories.
      */
-    void setIgnoreHiddenDirectories(bool b = true) { ignore_hidden_dirs_ = b; }
+    void setIgnoreHiddenDirectories(bool b = true)
+    {
+        ignore_hidden_dirs_ = b;
+    }
 
     /**
      * Enable or disable iterating over hidden files.
      * @param b Whether to skip hidden files.
      */
-    void setIgnoreHiddenFiles(bool b = true) { ignore_hidden_files_ = b; }
+    void setIgnoreHiddenFiles(bool b = true)
+    {
+        ignore_hidden_files_ = b;
+    }
 
     /**
      * Enable or disable returning directories in the iterator.
      * @param b Whether directories should be returned in the iterator.
      */
-    void setListDirectories(bool b = true) { list_dirs_ = b; }
+    void setListDirectories(bool b = true)
+    {
+        list_dirs_ = b;
+    }
 
     /**
      * Enable or disable returning files in the iterator.
      * @param b Whether files should be returned in the iterator.
      */
-    void setListFiles(bool b = true) { list_files_ = b; }
+    void setListFiles(bool b = true)
+    {
+        list_files_ = b;
+    }
 
     bool nextPath(Path& path);
 

--- a/include/tue/filesystem/crawler.h
+++ b/include/tue/filesystem/crawler.h
@@ -1,8 +1,9 @@
 #ifndef TUE_FILESYSTEM_CRAWLER_H_
 #define TUE_FILESYSTEM_CRAWLER_H_
 
-#include "path.h"
+/** @file crawler.h File system crawler definition. */
 
+#include "path.h"
 #include "boost/filesystem.hpp"
 
 namespace tue
@@ -10,41 +11,63 @@ namespace tue
 namespace filesystem
 {
 
+/**
+ * File system crawler, recursively walk over all files and directories in
+ * a tree from the provided root path.
+ */
 class Crawler
 {
-
 public:
-
     Crawler();
-
     Crawler(const Path& root_path);
-
     virtual ~Crawler();
 
     void setRootPath(const Path& path);
 
+    /**
+     * Enable or disable iterating over sub-directories.
+     * @param b Whether to expand sub-directories too.
+     */
     void setRecursive(bool b = true) { recursive_ = b; }
 
+    /**
+     * Enable or disable iterating over hidden directories.
+     * @param b Whether to skip hidden directories.
+     */
     void setIgnoreHiddenDirectories(bool b = true) { ignore_hidden_dirs_ = b; }
 
+    /**
+     * Enable or disable iterating over hidden files.
+     * @param b Whether to skip hidden files.
+     */
     void setIgnoreHiddenFiles(bool b = true) { ignore_hidden_files_ = b; }
 
+    /**
+     * Enable or disable returning directories in the iterator.
+     * @param b Whether directories should be returned in the iterator.
+     */
     void setListDirectories(bool b = true) { list_dirs_ = b; }
 
+    /**
+     * Enable or disable returning files in the iterator.
+     * @param b Whether files should be returned in the iterator.
+     */
     void setListFiles(bool b = true) { list_files_ = b; }
 
     bool nextPath(Path& path);
 
 private:
+    bool recursive_;           ///< If set, iterator also returns content of sub-directories.
+    bool ignore_hidden_dirs_;  ///< If set, hidden directories are not expanded.
+    bool ignore_hidden_files_; ///< If set, hidden files are not returned in the iterator.
+    bool list_dirs_;           ///< If set, iterator returns found directories.
+    bool list_files_;          ///< If set, iterator returns found files.
 
-    bool recursive_, ignore_hidden_dirs_, ignore_hidden_files_, list_dirs_, list_files_;
-
+    /** Internal file system iterator. */
     boost::filesystem::recursive_directory_iterator it_dir_;
-
 };
 
-}
-
-}
+} // end filesystem namespace
+} // end tue namespace
 
 #endif

--- a/include/tue/filesystem/crawler.h
+++ b/include/tue/filesystem/crawler.h
@@ -6,8 +6,10 @@
 #include "path.h"
 #include "boost/filesystem.hpp"
 
-namespace tue {
-namespace filesystem {
+namespace tue
+{
+namespace filesystem
+{
 
 /**
  * File system crawler, recursively walk over all files and directories in

--- a/include/tue/filesystem/path.h
+++ b/include/tue/filesystem/path.h
@@ -1,6 +1,8 @@
 #ifndef TUE_FILESYSTEM_PATH_H_
 #define TUE_FILESYSTEM_PATH_H_
 
+/** @file path.h File system path class. */
+
 #include <string>
 #include <ctime>
 
@@ -9,55 +11,53 @@ namespace tue
 namespace filesystem
 {
 
+/**
+ * Path class for a file system path, providing several useful functions for querying
+ * and manipulating a path.
+ */
 class Path
 {
-
 public:
-
     Path();
-
-    Path(const char* path) : path_(path) {}
-
     Path(const std::string& path);
+
+    /**
+     * Overloaded constructor for \code char* paths.
+     * @param path Path to set in the object.
+     */
+    Path(const char* path) : path_(path) {}
 
     virtual ~Path();
 
+    /**
+     * Get the complete path.
+     * @return The entire path, as stored in in the object.
+     */
     const std::string& string() const { return path_; }
-
     std::string extension() const;
-
+    std::string filename() const;
     Path parentPath() const;
 
     bool exists() const;
-
     bool isRegularFile() const;
-
     bool isDirectory() const;
-
     std::time_t lastWriteTime() const;
 
     Path& removeExtension();
-
     Path withoutExtension() const;
-
     Path join(const Path& path) const;
 
-    std::string filename() const;
-
+    /** Support printing the path. */
     friend std::ostream& operator<< (std::ostream& out, const Path& p) {
         out << p.path_;
         return out;
     }
 
 private:
-
-    std::string path_;
-
-
+    std::string path_; ///< Text of the file system path.
 };
 
-}
-
-}
+} // end filesystem namespace
+} // end tue namespace
 
 #endif

--- a/include/tue/filesystem/path.h
+++ b/include/tue/filesystem/path.h
@@ -6,8 +6,10 @@
 #include <string>
 #include <ctime>
 
-namespace tue {
-namespace filesystem {
+namespace tue
+{
+namespace filesystem
+{
 
 /**
  * Path class for a file system path, providing several useful functions for querying

--- a/include/tue/filesystem/path.h
+++ b/include/tue/filesystem/path.h
@@ -6,10 +6,8 @@
 #include <string>
 #include <ctime>
 
-namespace tue
-{
-namespace filesystem
-{
+namespace tue {
+namespace filesystem {
 
 /**
  * Path class for a file system path, providing several useful functions for querying
@@ -25,7 +23,9 @@ public:
      * Overloaded constructor for \code char* paths.
      * @param path Path to set in the object.
      */
-    Path(const char* path) : path_(path) {}
+    Path(const char* path) : path_(path)
+    {
+    }
 
     virtual ~Path();
 
@@ -33,7 +33,11 @@ public:
      * Get the complete path.
      * @return The entire path, as stored in in the object.
      */
-    const std::string& string() const { return path_; }
+    const std::string& string() const
+    {
+        return path_;
+    }
+
     std::string extension() const;
     std::string filename() const;
     Path parentPath() const;

--- a/src/crawler.cpp
+++ b/src/crawler.cpp
@@ -3,8 +3,10 @@
 #include "tue/filesystem/crawler.h"
 #include <iostream>
 
-namespace tue {
-namespace filesystem {
+namespace tue
+{
+namespace filesystem
+{
 
 /**
  * Default constructor of the crawler iterator class.
@@ -52,40 +54,54 @@ bool Crawler::nextPath(Path& path)
 {
     boost::filesystem::recursive_directory_iterator end;
 
-    while(it_dir_ != end) {
+    while(it_dir_ != end)
+    {
         // Compute whether the current name should be returned to the caller.
         bool found = false;
-        if (list_files_ && boost::filesystem::is_regular_file(*it_dir_)) {
-            if (!ignore_hidden_files_ || it_dir_->path().filename().string()[0] != '.') {
+
+        if (list_files_ && boost::filesystem::is_regular_file(*it_dir_))
+        {
+            if (!ignore_hidden_files_ || it_dir_->path().filename().string()[0] != '.')
+            {
                 path = it_dir_->path().string();
                 found = true;
             }
-        } else if (boost::filesystem::is_directory(*it_dir_)) {
-            if (!ignore_hidden_dirs_ || it_dir_->path().filename().string()[0] != '.') {
-                if (list_dirs_) {
+        }
+        else if (boost::filesystem::is_directory(*it_dir_))
+        {
+            if (!ignore_hidden_dirs_ || it_dir_->path().filename().string()[0] != '.')
+            {
+                if (list_dirs_)
+                {
                     path = it_dir_->path().string();
                     found = true;
                 }
 
-                if (!recursive_) it_dir_.no_push();
-
-            } else {
+                if (!recursive_)
+                    it_dir_.no_push();
+            }
+            else
+            {
                 it_dir_.no_push();
             }
         }
 
         // Advance to the next file or directory.
-        try {
+        try
+        {
             ++it_dir_;
-
-        } catch(std::exception& ex) {
+        }
+        catch(std::exception& ex)
+        {
             // We couldn't access the next item in the collection, so we assume it refers to a directory that we can't
             // access and we ask the iterator class not to navigate in that directory but skip to the next element.
+
             std::cout << ex.what() << std::endl;
             it_dir_.no_push();
         }
 
-        if (found) return true;
+        if (found)
+            return true;
     }
 
     return false;

--- a/src/crawler.cpp
+++ b/src/crawler.cpp
@@ -3,10 +3,8 @@
 #include "tue/filesystem/crawler.h"
 #include <iostream>
 
-namespace tue
-{
-namespace filesystem
-{
+namespace tue {
+namespace filesystem {
 
 /**
  * Default constructor of the crawler iterator class.
@@ -54,52 +52,40 @@ bool Crawler::nextPath(Path& path)
 {
     boost::filesystem::recursive_directory_iterator end;
 
-    while(it_dir_ != end)
-    {
+    while(it_dir_ != end) {
+        // Compute whether the current name should be returned to the caller.
         bool found = false;
-
-        if (list_files_ && boost::filesystem::is_regular_file(*it_dir_))
-        {
-            if (!ignore_hidden_files_ || it_dir_->path().filename().string()[0] != '.')
-            {
+        if (list_files_ && boost::filesystem::is_regular_file(*it_dir_)) {
+            if (!ignore_hidden_files_ || it_dir_->path().filename().string()[0] != '.') {
                 path = it_dir_->path().string();
                 found = true;
             }
-        }
-        else if (boost::filesystem::is_directory(*it_dir_))
-        {
-            if (!ignore_hidden_dirs_ || it_dir_->path().filename().string()[0] != '.')
-            {
-                if (list_dirs_)
-                {
+        } else if (boost::filesystem::is_directory(*it_dir_)) {
+            if (!ignore_hidden_dirs_ || it_dir_->path().filename().string()[0] != '.') {
+                if (list_dirs_) {
                     path = it_dir_->path().string();
                     found = true;
                 }
 
-                if (!recursive_)
-                    it_dir_.no_push();
-            }
-            else
-            {
+                if (!recursive_) it_dir_.no_push();
+
+            } else {
                 it_dir_.no_push();
             }
         }
 
-        try
-        {
+        // Advance to the next file or directory.
+        try {
             ++it_dir_;
-        }
-        catch(std::exception& ex)
-        {
+
+        } catch(std::exception& ex) {
             // We couldn't access the next item in the collection, so we assume it refers to a directory that we can't
             // access and we ask the iterator class not to navigate in that directory but skip to the next element.
-
             std::cout << ex.what() << std::endl;
             it_dir_.no_push();
         }
 
-        if (found)
-            return true;
+        if (found) return true;
     }
 
     return false;

--- a/src/crawler.cpp
+++ b/src/crawler.cpp
@@ -1,5 +1,6 @@
-#include "tue/filesystem/crawler.h"
+/** @file crawler.cpp Implementation of the file system crawler. */
 
+#include "tue/filesystem/crawler.h"
 #include <iostream>
 
 namespace tue
@@ -7,36 +8,48 @@ namespace tue
 namespace filesystem
 {
 
-// ----------------------------------------------------------------------------------------------------
-
-Crawler::Crawler() : recursive_(true), ignore_hidden_dirs_ (true), ignore_hidden_files_(true), list_dirs_(false), list_files_(true)
+/**
+ * Default constructor of the crawler iterator class.
+ * Creates an iterator that returns all non-hidden files in all non-hidden (sub-)directories.
+ * @note Root path must be set usng #setRootPath before usage.
+ */
+Crawler::Crawler() : recursive_(true), ignore_hidden_dirs_(true), ignore_hidden_files_(true),
+        list_dirs_(false), list_files_(true)
 {
 }
 
-// ----------------------------------------------------------------------------------------------------
-
-Crawler::Crawler(const Path& root_path) : recursive_(true), ignore_hidden_dirs_ (true), ignore_hidden_files_(true),
-    list_dirs_(false), list_files_(true)
+/**
+ * Constructor of the crawler iterator with a root path.
+ * Creates an iterator that returns all non-hidden files in all non-hidden (sub-)directories.
+ * @param root_path Starting point of the sub-tree to expand.
+ */
+Crawler::Crawler(const Path& root_path) : recursive_(true), ignore_hidden_dirs_(true),
+        ignore_hidden_files_(true), list_dirs_(false), list_files_(true)
 {
     setRootPath(root_path);
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/** Desctructor. */
 Crawler::~Crawler()
 {
 }
 
-// ----------------------------------------------------------------------------------------------------
-
-void Crawler::setRootPath(const Path& path)
+/**
+ * Sets (or change) the root path of the crawler instance.
+ * Also resets the iteration.
+ * @param root_path New root path to use for the iteration.
+ */
+void Crawler::setRootPath(const Path& root_path)
 {
-    boost::filesystem::path p(path.string());
+    boost::filesystem::path p(root_path.string());
     it_dir_ = boost::filesystem::recursive_directory_iterator(p);
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Get the next path at the file system of the crawl.
+ * @param path [out] Next found path at the file system, if the function returns successfully.
+ * @return Whether a next path was found, otherwise the crawl is finished.
+ */
 bool Crawler::nextPath(Path& path)
 {
     boost::filesystem::recursive_directory_iterator end;
@@ -92,6 +105,5 @@ bool Crawler::nextPath(Path& path)
     return false;
 }
 
-}
-
-}
+} // end filesystem namespace
+} // end tue namespace

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -24,7 +24,7 @@ Path::~Path()
 
 /**
  * Get the last extension of the path if available.
- * @return The last extensionof the path including the leading dot, or the empty string.
+ * @return The last extension of the path including the leading dot, or the empty string.
  */
 std::string Path::extension() const
 {

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1,5 +1,6 @@
-#include "tue/filesystem/path.h"
+/** @file path.cpp Implementation of the path class. */
 
+#include "tue/filesystem/path.h"
 #include "boost/filesystem.hpp"
 
 namespace tue
@@ -7,38 +8,46 @@ namespace tue
 namespace filesystem
 {
 
-// ----------------------------------------------------------------------------------------------------
-
+/** Default constructor, without setting a valid path. */
 Path::Path()
 {
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Regular constructor.
+ * @param path Path to set.
+ */
 Path::Path(const std::string& path) : path_(path) {}
 
-// ----------------------------------------------------------------------------------------------------
-
+/** Destructor. */
 Path::~Path()
 {
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Get the last extension of the path if available.
+ * @return The last extensionof the path including the leading dot, or the empty string.
+ */
 std::string Path::extension() const
 {
     return boost::filesystem::path(path_).extension().string();
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Return the part of the path after the last directory separator.
+ * @return The name part after the last directory separator, if it exists.
+ *      If the path represents the file system root (\c "/"), the path itself is returned, else \c "." is returned.
+ */
 std::string Path::filename() const
 {
     return boost::filesystem::path(path_).filename().string();
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Get the parent directory of the path.
+ * @return The empty string is the path is the file system root (\c "/"), else the path without the #filename()
+ *      part and last directory separator.
+ */
 Path Path::parentPath() const
 {
     std::string str = boost::filesystem::path(path_).parent_path().string();
@@ -48,36 +57,49 @@ Path Path::parentPath() const
     return Path(str);
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Verify whether the path actually exists at the file system.
+ * @return Whether the path represents an existing path at the file system at the time of the call.
+ */
 bool Path::exists() const
 {
     return boost::filesystem::exists(boost::filesystem::path(path_));
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Test whether the path is a regular file.
+ * @return Whether the path is a regular file.
+ * @note Getting \c false does not imply the path is a directory.
+ */
 bool Path::isRegularFile() const
 {
     return boost::filesystem::is_regular_file(boost::filesystem::path(path_));
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Test whether the path is a directory.
+ * @return Whether the path is a directory.
+ * @note Getting \c false does not imply the path is a regular file.
+ */
 bool Path::isDirectory() const
 {
     return boost::filesystem::is_directory(boost::filesystem::path(path_));
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Get the last modification time of the path at the file system as reported by the OS.
+ * For directories, this may not include last modification time of its content.
+ * @return Last modification time of the path.
+ */
 std::time_t Path::lastWriteTime() const
 {
     return boost::filesystem::last_write_time(boost::filesystem::path(path_));
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Remove the extension from the path.
+ * @return The object after removal of the last extension.
+ */
 Path& Path::removeExtension()
 {
     std::string ext = extension();
@@ -88,8 +110,10 @@ Path& Path::removeExtension()
     return *this;
 }
 
-// ----------------------------------------------------------------------------------------------------
-
+/**
+ * Construct a new path from this path while removing the extension from it.
+ * @return Same path as the object, but without last extension.
+ */
 Path Path::withoutExtension() const
 {
     std::string ext = extension();
@@ -103,19 +127,21 @@ Path Path::withoutExtension() const
     return p;
 }
 
-// ----------------------------------------------------------------------------------------------------
-
-Path Path::join(const Path& path) const
+/**
+ * Construct a new path by appending the given \a sub_path to this path.
+ * @param sub_path Path to append to this path.
+ * @return New path consisting of this path, appended with \a sub_path.
+ */
+Path Path::join(const Path& sub_path) const
 {
     Path p(*this);
 
     if (!p.path_.empty() && p.path_[p.path_.size() - 1] != '/')
         p.path_ += '/';
 
-    p.path_ += path.path_;
+    p.path_ += sub_path.path_;
     return p;
 }
 
-}
-
-}
+} // end filesystem namespace
+} // end tue namespace

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -3,10 +3,8 @@
 #include "tue/filesystem/path.h"
 #include "boost/filesystem.hpp"
 
-namespace tue
-{
-namespace filesystem
-{
+namespace tue {
+namespace filesystem {
 
 /** Default constructor, without setting a valid path. */
 Path::Path()
@@ -51,8 +49,9 @@ std::string Path::filename() const
 Path Path::parentPath() const
 {
     std::string str = boost::filesystem::path(path_).parent_path().string();
-    if (str.empty())
+    if (str.empty()) {
         str = ".";
+    }
 
     return Path(str);
 }
@@ -104,8 +103,9 @@ Path& Path::removeExtension()
 {
     std::string ext = extension();
 
-    if (!ext.empty())
+    if (!ext.empty()) {
         path_ = path_.substr(0, path_.size() - ext.size());
+    }
 
     return *this;
 }
@@ -119,10 +119,11 @@ Path Path::withoutExtension() const
     std::string ext = extension();
 
     Path p;
-    if (!ext.empty())
+    if (!ext.empty()) {
         p.path_ = path_.substr(0, path_.size() - ext.size());
-    else
+    } else {
         p = *this;
+    }
 
     return p;
 }
@@ -136,8 +137,9 @@ Path Path::join(const Path& sub_path) const
 {
     Path p(*this);
 
-    if (!p.path_.empty() && p.path_[p.path_.size() - 1] != '/')
+    if (!p.path_.empty() && p.path_[p.path_.size() - 1] != '/') {
         p.path_ += '/';
+    }
 
     p.path_ += sub_path.path_;
     return p;

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -3,8 +3,10 @@
 #include "tue/filesystem/path.h"
 #include "boost/filesystem.hpp"
 
-namespace tue {
-namespace filesystem {
+namespace tue
+{
+namespace filesystem
+{
 
 /** Default constructor, without setting a valid path. */
 Path::Path()
@@ -49,9 +51,8 @@ std::string Path::filename() const
 Path Path::parentPath() const
 {
     std::string str = boost::filesystem::path(path_).parent_path().string();
-    if (str.empty()) {
+    if (str.empty())
         str = ".";
-    }
 
     return Path(str);
 }
@@ -103,9 +104,8 @@ Path& Path::removeExtension()
 {
     std::string ext = extension();
 
-    if (!ext.empty()) {
+    if (!ext.empty())
         path_ = path_.substr(0, path_.size() - ext.size());
-    }
 
     return *this;
 }
@@ -119,11 +119,10 @@ Path Path::withoutExtension() const
     std::string ext = extension();
 
     Path p;
-    if (!ext.empty()) {
+    if (!ext.empty())
         p.path_ = path_.substr(0, path_.size() - ext.size());
-    } else {
+    else
         p = *this;
-    }
 
     return p;
 }
@@ -137,9 +136,8 @@ Path Path::join(const Path& sub_path) const
 {
     Path p(*this);
 
-    if (!p.path_.empty() && p.path_[p.path_.size() - 1] != '/') {
+    if (!p.path_.empty() && p.path_[p.path_.size() - 1] != '/')
         p.path_ += '/';
-    }
 
     p.path_ += sub_path.path_;
     return p;


### PR DESCRIPTION
@MatthijsBurgh I don't know exactly who else has interest in this, but it would seem useful imho to invite others to chime in as well.


I found this package to be a good target to start documenting (small and simple, so easy to do, and simple to change), and since I was asked about how to add documentation to the CPP code, I made this PR as an example, and point of discussing what is desired.

The entire idea about adding Doxygen documentation (doxymentation) is to create a second, higher level reference what the function/method is doing. It should contain all information required to use the function, which includes

1. What does the function do.
2. What are its arguments, in particular value ranges, and meaning of values (units, meaning of special values like ``0``, are negative values allowed, and what do they do, etc)
3. What output does the function give me, in terms of functionality and the input parameters.

In other words, with the text and the function header, you can call the function and know what to expect from it. Since we are much faster in reading 6 lines of text than we are in decoding 50+ lines of cpp code (in particular wrt edge cases and meaning of values), this actually speeds up your work.

Adding a second description introduces the possibility of inconsistencies, ie the code may do something else than the text says. Decisions how to unify it again should be made on common sense, but using the text as leading works best in my experience, since that is what all calls used, and it gives a high level intentional description which is likely to be more stable over a longer period of time.

== About the commits attached to this Pr ==

Obviously, most things I changed are according to my preferences, but that doesn't imply this is how it should become. Documentation style and coding style are highly debated topics, the primary goal should be imho to get an agreement on what to do. This PR is an example of what can be changed, to start a discussion. I'll have no problem reverting some of the proposed changes if that helps in agree-ing on a documentation and code style. Making other changes can be done too, as far as I am concerned.

It is probably best to read each commit separately, below is a short explanation of why I made some changes. Also, you may want to see the 'before' and 'after' version of the files, as that gives a better impression how file looks.

cef6f5e5c8857a10a98690c4fd7e3a6fc6556eab
* @file header must be added to each file for Doxygen, or it doesn't process the comments.
* The consistent double lines in the entire file defeats the option to make groups of related functions/methods. I think having groups of related functions is useful to have.
* One block comment seems to give the least amount of clutter. I use 2 styles, either everything on a single line, or a ``/**`` at the first line and the ``*/`` below the doxyment.
* I use ``@`` rather than ``\`` mostly out of habit, Doxygen treats them as equivalent afaik.
* There is usually no need for explicit ``@brief`` and ``@detail``, the first sentence is the brief description, everything else is details.
* I add the documentation to the definition of the function, ie near the code. That increases the chance of keeping them consistent. Also, since code is large already, adding the comment doesn't add much clutter.
* You can also add comment after the definition. This makes a lot of sense with variables, (eg crawler.h new line 60-64) I used ``///<` as prefix, Doxygen has several other forms.
* Adding a comment near the end of the namespace made sense to me.
* In the cpp code, the ``----------------------`` lines aren't much needed anymore, the doxyment text serves as separator.
* In the text I used ``#method`` to create a link to the mentioned method, ``\c stuff`` to make ``stuff`` be formatted in code tags, and ``\a arg`` to refer to other arguments of a function.

0d3bb0e5847dbaf5b1c29e7e3b550d1eb9aa21f6

* This is mostly about reducing vertical space, having curly brackets on a separate line means you're wasting almost half the lines of your display. Also, it makes groups of code invisible, as almost every second line looks like a separator line.
* I made the outermost curly brackets of a function always at a separate line, which is somewhat a contradiction to the previous point. Mostly this is about consistency, another option can be to move the opening bracket of a method to the end of the function header line everywhere.
* In the ``nextPath`` function, the effect of not using separate lines for curly brackets is most clear. It reduces the function from 52 to 40 lines, while adding a comment line above each of the 2 steps.
* The unbracketed multi-line statement (like line 54 in old path.cpp) is quite fragile, it is easy to make mistakes there. I changed it either to a bracketed version, or to a single line version (eg line 88 in the new crawler.cpp file).

As a final note, at some point functions become so trivial that documentation is almost useless. Not documenting such functions is an option of course, but that opens the problem of deciding _what is trivial enough?_ I avoid that entire problem by just documenting everything. Such trivial functions are also trivial to document, so such discussion is soon taking more time than just writing a few lines of comment.

== Converting everything else ==
As for converting the entire code base, I believe we should first agree on some style for documentation and code, and fixate this by writing it down somewhere.
Next step would be stop accepting PRs that add functions without proper documentation.
To speed up the conversion, we could also stop accepting PRs that modify functions without proper documentation.
PRs that only add documentation are welcome, and imho very useful, but they are boring to write, so the quality of them is soon too low to be useful.
